### PR TITLE
Feature/error handler coverage

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -109,6 +109,7 @@ def create_promotions():
         {"Location": location_url},
     )
 
+
 ######################################################################
 # UPDATE PROMOTION
 ######################################################################
@@ -139,6 +140,7 @@ def update_promotion(promotion_id):
     app.logger.info(f"Promotion with ID [{promotion_id}] updated successfully.")
 
     return jsonify(promotion.serialize()), status.HTTP_200_OK
+
 
 ######################################################################
 # DELETE A PROMOTION

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -190,6 +190,20 @@ class TestPromotionResourceService(TestCase):
         self.assertEqual(new_promotion["extra"]["value"], test_promotion.extra["value"])
 
     # ----------------------------------------------------------
+    # TEST CREATE WITH 415 WRONG HEADERS
+    # ----------------------------------------------------------
+    def test_create_promotion_with_wrong_headers(self):
+        """It should raise a 415 unsupported media type error"""
+        test_promotion = PromotionFactory()
+        logging.debug("Test Promotion: %s", test_promotion.serialize())
+        response = self.client.post(
+            BASE_URL,
+            json=test_promotion.serialize(),
+            headers={"Content-Type": "some wrong value"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
+    # ----------------------------------------------------------
     # TEST UPDATE
     # ----------------------------------------------------------
     def test_update_promotion(self):
@@ -275,3 +289,11 @@ class TestPromotionResourceService(TestCase):
         response = self.client.delete(f"{BASE_URL}/{non_existent_id}")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(response.data), 0)
+
+    # ----------------------------------------------------------
+    # TEST INVALID METHODS
+    # ----------------------------------------------------------
+    def test_delete_invalid_methods(self):
+        """It should throw HTTP 405, METHOD_NOT_ALLOWED"""
+        response = self.client.delete(f"{BASE_URL}")
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -28,7 +28,7 @@ from wsgi import app
 from service.common import status
 from service.models import db, Promotion
 from .factories import PromotionFactory
-import uuid 
+import uuid
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -189,7 +189,9 @@ class TestPromotionResourceService(TestCase):
         )
         self.assertEqual(new_promotion["extra"]["value"], test_promotion.extra["value"])
 
-
+    # ----------------------------------------------------------
+    # TEST UPDATE
+    # ----------------------------------------------------------
     def test_update_promotion(self):
         """It should update an existing promotion"""
         test_promotion = self._create_promotions(1)[0]
@@ -203,10 +205,7 @@ class TestPromotionResourceService(TestCase):
             "created_by": test_promotion.created_by,
             "updated_by": str(uuid.uuid4()),
             "product_ids": test_promotion.product_ids,
-            "extra": {
-                "promotion_type": "percentage",
-                "value": 15
-            }
+            "extra": {"promotion_type": "percentage", "value": 15},
         }
 
         response = self.client.put(f"{BASE_URL}/{test_promotion.id}", json=updated_data)
@@ -217,19 +216,30 @@ class TestPromotionResourceService(TestCase):
         self.assertEqual(updated_promotion["name"], updated_data["name"])
         self.assertEqual(updated_promotion["description"], updated_data["description"])
         self.assertEqual(
-            datetime.fromisoformat(updated_promotion["start_date"]).replace(tzinfo=timezone.utc),
-            test_promotion.start_date
+            datetime.fromisoformat(updated_promotion["start_date"]).replace(
+                tzinfo=timezone.utc
+            ),
+            test_promotion.start_date,
         )
         self.assertEqual(
-            datetime.fromisoformat(updated_promotion["end_date"]).replace(tzinfo=timezone.utc),
-            test_promotion.end_date
+            datetime.fromisoformat(updated_promotion["end_date"]).replace(
+                tzinfo=timezone.utc
+            ),
+            test_promotion.end_date,
         )
-        self.assertEqual(updated_promotion["active_status"], updated_data["active_status"])
+        self.assertEqual(
+            updated_promotion["active_status"], updated_data["active_status"]
+        )
         self.assertEqual(updated_promotion["created_by"], updated_data["created_by"])
         self.assertEqual(updated_promotion["updated_by"], updated_data["updated_by"])
         self.assertEqual(updated_promotion["product_ids"], updated_data["product_ids"])
-        self.assertEqual(updated_promotion["extra"]["promotion_type"], updated_data["extra"]["promotion_type"])
-        self.assertEqual(updated_promotion["extra"]["value"], updated_data["extra"]["value"])
+        self.assertEqual(
+            updated_promotion["extra"]["promotion_type"],
+            updated_data["extra"]["promotion_type"],
+        )
+        self.assertEqual(
+            updated_promotion["extra"]["value"], updated_data["extra"]["value"]
+        )
 
     # ----------------------------------------------------------
     # TEST DELETE
@@ -250,4 +260,3 @@ class TestPromotionResourceService(TestCase):
         response = self.client.delete(f"{BASE_URL}/{non_existent_id}")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(response.data), 0)
-

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -242,6 +242,21 @@ class TestPromotionResourceService(TestCase):
         )
 
     # ----------------------------------------------------------
+    # TEST UPDATE 400 BAD_REQUEST
+    # ----------------------------------------------------------
+    def test_update_promotion_bad_request(self):
+        """It should not update an promotion with bad request"""
+        test_promotion = self._create_promotions(1)[0]
+
+        # bad update data structure
+        updated_data = {
+            "123": 123,
+        }
+
+        response = self.client.put(f"{BASE_URL}/{test_promotion.id}", json=updated_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # ----------------------------------------------------------
     # TEST DELETE
     # ----------------------------------------------------------
     def test_delete_promotion(self):


### PR DESCRIPTION
format: auto formatting jobs for test_routes file.
error_handler coverage: cover HTTP_STATUS_CODE 400, 405, 415, 404(already covered, check again)

remaining: maybe 500 is needed, but does not make sense. TBD.

<img width="538" alt="image" src="https://github.com/user-attachments/assets/0c19e0c6-1288-4cb8-96b6-07bf846ecc90">