### PR TITLE
Sync promotion id type to UUID only for all APIs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,7 +65,8 @@
 				"inercia.vscode-k3d",
 				"rangav.vscode-thunder-client",
 				"bbenoist.vagrant",
-				"streetsidesoftware.code-spell-checker"
+				"streetsidesoftware.code-spell-checker",
+				"mhutchie.git-graph"  // Added Git Graph extension
 			]
 		}
 	},

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ As a convenience you can aso use:
 make run
 ```
 
-You should be able to reach the service at: http://localhost:8000. The port that is used is controlled by an environment variable defined in the `.flaskenv` file which Flask uses to load it's configuration from the environment by default.
+You should be able to reach the service at: http://0.0.0.0:8080. The port that is used is controlled by an environment variable defined in the `.flaskenv` file which Flask uses to load it's configuration from the environment by default.
 
 ## License
 

--- a/service/common/route_utils.py
+++ b/service/common/route_utils.py
@@ -1,0 +1,40 @@
+# import uuid
+from flask import request, abort
+from flask import current_app as app  # Import Flask application
+from service.common import status  # HTTP Status Codes
+
+
+######################################################################
+#  U T I L I T Y   F U N C T I O N S
+######################################################################
+
+
+######################################################################
+# Checks the ContentType of a request (same function as prof's example)
+######################################################################
+def check_content_type(content_type) -> None:
+    """Checks that the media type is correct"""
+    if request.headers.get("Content-Type", "") == content_type:
+        return
+
+    app.logger.error("Invalid Content-Type: %s", request.headers["Content-Type"])
+    abort(
+        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+        f"Content-Type must be {content_type}",
+    )
+
+
+# ######################################################################
+# # Checks whether a string is uuid4 string.
+# ######################################################################
+# def is_uuid4(uuid_string: str) -> bool:
+#     """Check if a string is a valid UUID4"""
+#     try:
+#         # Try to convert the string to a UUID
+#         val = uuid.UUID(uuid_string, version=4)
+#     except ValueError:
+#         # If it's a ValueError, then it's not a valid UUID
+#         return False
+
+#     # Check if the UUID is version 4
+#     return val.version == 4

--- a/service/routes.py
+++ b/service/routes.py
@@ -53,7 +53,7 @@ def index():
 ######################################################################
 # READ A PROMOTION
 ######################################################################
-@app.route("/promotions/<string:promotion_id>", methods=["GET"])
+@app.route("/promotions/<uuid:promotion_id>", methods=["GET"])
 def get_promotions(promotion_id):
     """
     Retrieve a single Promotion
@@ -62,12 +62,7 @@ def get_promotions(promotion_id):
     """
     app.logger.info("Request to Retrieve a promotion with id [%s]", promotion_id)
 
-    # Attempt to find the Promotion and abort if not found
-    promotion = None
-
-    # check if promotion_id is uuid4
-    if is_uuid4(promotion_id):
-        promotion = Promotion.find(promotion_id)
+    promotion = Promotion.find(promotion_id)
 
     if not promotion:
         abort(
@@ -113,7 +108,7 @@ def create_promotions():
 ######################################################################
 # UPDATE PROMOTION
 ######################################################################
-@app.route("/promotions/<string:promotion_id>", methods=["PUT"])
+@app.route("/promotions/<uuid:promotion_id>", methods=["PUT"])
 def update_promotion(promotion_id):
     """
     Update an existing Promotion

--- a/service/routes.py
+++ b/service/routes.py
@@ -21,11 +21,11 @@ This service implements a REST API that allows you to Create, Read, Update
 and Delete Promotion
 """
 
-import uuid
 from flask import jsonify, request, url_for, abort
 from flask import current_app as app  # Import Flask application
 from service.models import Promotion
 from service.common import status  # HTTP Status Codes
+from service.common.route_utils import check_content_type
 
 
 ######################################################################
@@ -175,39 +175,3 @@ def list_promotions():
     promos = Promotion.query.all()
     result = [promotion.serialize() for promotion in promos]
     return jsonify(result), status.HTTP_200_OK
-
-
-######################################################################
-#  U T I L I T Y   F U N C T I O N S
-######################################################################
-
-
-######################################################################
-# Checks the ContentType of a request (same function as prof's example)
-######################################################################
-def check_content_type(content_type) -> None:
-    """Checks that the media type is correct"""
-    if request.headers.get("Content-Type", "") == content_type:
-        return
-
-    app.logger.error("Invalid Content-Type: %s", request.headers["Content-Type"])
-    abort(
-        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-        f"Content-Type must be {content_type}",
-    )
-
-
-######################################################################
-# Checks whether a string is uuid4 string.
-######################################################################
-def is_uuid4(uuid_string: str) -> bool:
-    """Check if a string is a valid UUID4"""
-    try:
-        # Try to convert the string to a UUID
-        val = uuid.UUID(uuid_string, version=4)
-    except ValueError:
-        # If it's a ValueError, then it's not a valid UUID
-        return False
-
-    # Check if the UUID is version 4
-    return val.version == 4

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -255,6 +255,14 @@ class TestPromotionResourceService(TestCase):
             updated_promotion["extra"]["value"], updated_data["extra"]["value"]
         )
 
+    def test_update_promotion_with_non_uuid_id(self):
+        """It should raise a 404 Method Not Found error when a non-UUID type promotion ID is used"""
+
+        non_uuid_id = "not-a-uuid"
+
+        response = self.client.put(f"{BASE_URL}/{non_uuid_id}", json={})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     # ----------------------------------------------------------
     # TEST UPDATE 400 BAD_REQUEST
     # ----------------------------------------------------------


### PR DESCRIPTION
**Changes**
- Update the port description in `README.md` to `8080` to match the settings in `flaskenv`.
- Include the Git Graph Extension in the Docker Container configuration to provide access to the git history.
- Modify all REST API endpoints to only accept `promotion_id` as a UUID type.
- Relocate utility functions to `route_utils` to facilitate future expansion.

**Note**
In Flask, when we specify a type constraint like `<uuid:promotion_id>` in a route, Flask pre-validates that the parameter in the URL matches the expected type. If you pass a parameter that doesn't conform to the specified type, such as providing a non-UUID string like `"abc"` for a UUID-constrained parameter, Flask will fail to match the route entirely. Because it doesn’t find a matching route for the URL pattern with a valid UUID, it returns a `404 Not Found` error instead of a `400 Bad Request`.

Results:
![Screenshot 2024-10-24 at 4 34 55 PM](https://github.com/user-attachments/assets/92c26b53-14ad-40eb-a30c-352680b54183)
![Screenshot 2024-10-24 at 3 54 46 PM](https://github.com/user-attachments/assets/690b2c6f-cef9-4996-9593-016e3eda7afd)


