### PR TITLE
Improve/delete update ci tasks

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -4,6 +4,7 @@ Environment for Behave Testing
 
 from os import getenv
 from selenium import webdriver
+import logging
 
 WAIT_SECONDS = int(getenv("WAIT_SECONDS", "60"))
 BASE_URL = getenv("BASE_URL", "http://localhost:8080")
@@ -14,6 +15,10 @@ def before_all(context):
     """Executed once before all tests"""
     context.base_url = BASE_URL
     context.wait_seconds = WAIT_SECONDS
+
+    # Setup logging
+    setup_logging(context)
+
     # Select either Chrome or Firefox
     if "firefox" in DRIVER:
         context.driver = get_firefox()
@@ -47,3 +52,20 @@ def get_firefox():
     options = webdriver.FirefoxOptions()
     options.add_argument("--headless")
     return webdriver.Firefox(options=options)
+
+
+def setup_logging(context):
+    logging.basicConfig(
+        filename="behave.log",
+        level=logging.INFO,
+        filemode="w",
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(name)-12s: %(levelname)-8s %(message)s")
+    console.setFormatter(formatter)
+    logging.getLogger("").addHandler(console)
+
+    context.logger = logging.getLogger("behave_logger")

--- a/features/promotions.feature
+++ b/features/promotions.feature
@@ -29,13 +29,6 @@ Feature: The promotions service back-end
         And I press the "Create" button
         Then I should see the message "Success"
 
-    Scenario: Retrieve a Promotion
-        When I visit the "Home Page"
-        And I switch to the "Retrieve Promotion" tab
-        And I set the "ID" to "550e8400-e29b-41d4-a716-446655440000"
-        And I press the "Retrieve" button
-        Then I should see the message "Success"
-
     Scenario: Creating a Promotion with an Invalid Creator's UUID
         When I visit the "Home Page"
         And I switch to the "Create A Promotion" tab
@@ -99,27 +92,47 @@ Feature: The promotions service back-end
         And I press the "Search" button
         Then I should see the promotion "Winter Sale" between "2024-12-01T00:00:00" and "2024-12-31T23:59:59" in the search results
 
-    Scenario: Updating promotions
-        When I visit the "Home Page"
-        And I switch to the "Update A Promotion" tab
-        And I set the "ID" to "fe0e7528-271e-4e18-b209-4de72cbba141"
-        And I set the "Creator's UUID" to "fe0e7528-271e-4e18-b209-4de72cbba142"
-        And I set the "Updater's UUID" to "fe0e7528-271e-4e18-b209-4de72cbba143"
-        And I set the "Name" to "not_free"
-        And I set the "Description" to "sss"
-        And I set the "Product IDs" to "prod_3"
-        And I set the "Start Date" to "2024-11-12"
-        And I set the "End Date" to "2024-11-25"
-        And I set the "Active Status" to "Inactive"
-        And I press the "Update" button
-        Then I should see the message "Update successful!"
-
-     # TODO: Add sad path for update promotions when fixing backend logic
-
     Scenario: Delete a Promotion
         When I visit the "Home Page"
         And I switch to the "Delete Promotion" tab
-        And I set the "ID" to "550e8400-e29b-41d4-a716-446655440000"
+        And I set the ID with last created UUID
         And I press the "Delete" button
-        Then I should see the message "Promotion has been Deleted!"
+        Then I should see the message "Promotion has been Deleted"
 
+    Scenario: Delete non existed Promotion
+        When I visit the "Home Page"
+        And I switch to the "Delete Promotion" tab
+        And I set the "ID" to "123e4567-e89b-12d3-a456-426614174000"
+        And I press the "Delete" button
+        Then I should see the message "404 Not Found: Promotion with id '123e4567-e89b-12d3-a456-426614174000' was not found."
+
+    Scenario: Updating promotions with Name, Description, End Date
+        When I visit the "Home Page"
+        And I switch to the "Update A Promotion" tab
+        And I set the ID with last created UUID
+        And I press the "Retrieve" button
+        Then I should see the message "Success"
+        When I set the "Name" to "not_free"
+        And I set the "Description" to "sss"
+        And I set the "End Date" to "2024-11-25"
+        And I press the "Update" button
+        Then I should see the message "Update successful!"
+    
+    Scenario: Updating promotions with invalid name value 
+        When I visit the "Home Page"
+        And I switch to the "Update A Promotion" tab
+        And I set the ID with last created UUID
+        And I press the "Retrieve" button
+        Then I should see the message "Success"
+        When I set the "Name" to " "
+        And I set the "Description" to "sss"
+        And I set the "End Date" to "11/25/2024"
+        And I press the "Update" button
+        Then I should see the message "Invalid Promotion: missing name"
+    
+    Scenario: Retrieve a non existed Promotion
+        When I visit the "Home Page"
+        And I switch to the "Update A Promotion" tab
+        And I set the "ID" to "123e4567-e89b-12d3-a456-426614174000"
+        And I press the "Retrieve" button
+        Then I should see the message "404 Not Found: Promotion with id '123e4567-e89b-12d3-a456-426614174000' was not found."

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -56,6 +56,18 @@ def step_impl(context, text_string):
     assert text_string not in element.text
 
 
+@when("I set the ID with last created UUID")
+def step_impl(context):
+    element_id = (
+        ACTION_PREFIX
+        + ID_PREFIX
+        + get_id_from_element_name("id").lower().replace(" ", "_")
+    )
+    element = context.driver.find_element(By.ID, element_id)
+    element.clear()
+    element.send_keys(context.last_created_uuid)
+
+
 @when('I set the "{element_name}" to "{text_string}"')
 def step_impl(context, element_name, text_string):
     element_id = (
@@ -65,10 +77,7 @@ def step_impl(context, element_name, text_string):
     )
     element = context.driver.find_element(By.ID, element_id)
 
-    if element_name == "ID":
-        element.clear()
-        element.send_keys(context.last_created_uuid)
-    elif element_name == "Active Status":
+    if element_name == "Active Status":
         select = Select(element)
         if text_string == "Active":
             select.select_by_value("true")
@@ -158,7 +167,7 @@ def step_impl(context, tab):
     context.driver.find_element(By.ID, tab_id).click()
 
 
-@then('I should see "{name}" in the results')
+@then('I should see "{name}" in the search results')
 def step_impl(context, name):
     found = WebDriverWait(context.driver, context.wait_seconds).until(
         expected_conditions.text_to_be_present_in_element(
@@ -168,21 +177,11 @@ def step_impl(context, name):
     assert found
 
 
-@then('I should see "{name}" in the search results')
-def step_impl(context, name):
-    found = WebDriverWait(context.driver, context.wait_seconds).until(
-        expected_conditions.text_to_be_present_in_element(
-            (By.ID, "search-promotion-data"), name
-        )
-    )
-    assert found
-
-
 @then(
     'I should see the promotion "{promotion_name}" between "{start_date}" and "{end_date}" in the search results'
 )
 def step_impl(context, promotion_name, start_date, end_date):
-    table = context.driver.find_element(By.CSS_SELECTOR, "#search-promotion-data tbody")
+    table = context.driver.find_element(By.CSS_SELECTOR, "#promotion-data tbody")
     rows = table.find_elements(By.TAG_NAME, "tr")  # Get all rows in the table body
 
     start_date_dt = datetime.strptime(start_date, "%Y-%m-%dT%H:%M:%S")
@@ -209,7 +208,7 @@ def step_impl(context, promotion_name, start_date, end_date):
     'I should see the promotion "{promotion_name}" with "{status}" Status in the search results'
 )
 def step_impl(context, promotion_name, status):
-    table = context.driver.find_element(By.CSS_SELECTOR, "#search-promotion-data tbody")
+    table = context.driver.find_element(By.CSS_SELECTOR, "#promotion-data tbody")
     rows = table.find_elements(By.TAG_NAME, "tr")  # Get all rows in the table body
 
     found_promotion = False

--- a/service/routes.py
+++ b/service/routes.py
@@ -150,11 +150,15 @@ def delete_promotions(promotion_id):
     # Delete the Promotion if it exists
     promotion = Promotion.find(promotion_id)
     if promotion:
-        app.logger.info("Promotion with ID: %d found.", promotion.id)
+        app.logger.info(f"Promotion with ID: {promotion.id} found. Deleting...")
         promotion.delete()
+        app.logger.info(f"Promotion with ID: {promotion_id} deletion complete.")
+        return jsonify({}), status.HTTP_204_NO_CONTENT
 
-    app.logger.info("Promotion with ID: %d delete complete.", promotion_id)
-    return {}, status.HTTP_204_NO_CONTENT
+    abort(
+        status.HTTP_404_NOT_FOUND,
+        f"Promotion with id '{promotion_id}' was not found.",
+    )
 
 
 ######################################################################

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -35,10 +35,9 @@
       <li role="presentation"><a id="search_promotions-tab" href="#search" aria-controls="search" role="tab"
           data-toggle="tab">Search
           Promotions</a></li>
-      <li role="presentation"><a id="retrieve_promotion-tab" href="#retrieve" aria-controls="retrieve" role="tab"
-          data-toggle="tab">Retrieve
-          Promotion</a></li>
-      <li role="presentation"><a id="delete_promotion-tab" href="#delete" aria-controls="delete" role="tab" data-toggle="tab">Delete Promotion</a>
+
+      <li role="presentation"><a id="delete_promotion-tab" href="#delete" aria-controls="delete" role="tab"
+          data-toggle="tab">Delete Promotion</a>
       </li>
       <li role="presentation"><a href="#update" aria-controls="update" role="tab" data-toggle="tab"
           id="update_a_promotion-tab">Update A
@@ -152,6 +151,15 @@
       <div role="tabpanel" class="tab-pane" id="search">
         <div class="well">
           <form id="searchPromotionForm" class="form-horizontal">
+
+            <!-- Search by Promotion ID -->
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="search_promotion_id">Promotion ID:</label>
+              <div class="col-sm-10">
+                <input type="text" class="form-control" id="search_promotion_id" placeholder="Search by Promotion ID">
+              </div>
+            </div>
+
             <!-- Search by Promotion Name -->
             <div class="form-group">
               <label class="control-label col-sm-2" for="search_promotion_name">Name:</label>
@@ -264,53 +272,6 @@
           </form>
         </div>
 
-        <div class="table-responsive col-md-12" id="search-promotion-data">
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Name</th>
-                <th>Description</th>
-                <th>Product IDs</th>
-                <th>Start Date</th>
-                <th>End Date</th>
-                <th>Active Status</th>
-                <th>Creator</th>
-                <th>Updater</th>
-                <th>Created At</th>
-                <th>Updated At</th>
-                <th>Extra</th>
-              </tr>
-            </thead>
-            <tbody>
-              <!-- Dynamic content filled by JavaScript/AJAX upon search -->
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <!-- Retrieve Promotion Tab Pane -->
-      <div role="tabpanel" class="tab-pane" id="retrieve">
-        <div class="well">
-          <form id="retrievePromotionForm" class="form-horizontal">
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="retrieve_promotion_id">Promotion ID:</label>
-              <div class="col-sm-10">
-                <input type="text" class="form-control" id="retrieve_promotion_id"
-                  placeholder="Enter ID of Promotion to Retrieve">
-              </div>
-            </div>
-
-            <div class="form-group">
-              <div class="col-sm-offset-2 col-sm-10 d-flex gap-2">
-                <button type="submit" class="btn btn-primary" id="retrieve-btn">Retrieve</button>
-                <button type="button" id="clear-retrieve" class="btn btn-secondary"
-                  onclick="clearForm('retrieve')">Clear</button>
-              </div>
-            </div>
-          </form>
-        </div>
-
         <div class="table-responsive col-md-12" id="promotion-data">
           <table class="table table-striped">
             <thead>
@@ -359,33 +320,19 @@
         </div>
       </div>
 
-
-
-      <!-- Update Promotion Tab Pane -->
+      <!-- Combined Retrieve and Update Promotion Tab Pane -->
       <div role="tabpanel" class="tab-pane" id="update">
         <div class="well">
           <form id="updatePromotionForm" class="form-horizontal">
             <!-- Promotion ID (Required for Update) -->
             <div class="form-group">
               <label class="control-label col-sm-2" for="update_promotion_id">Promotion ID:</label>
-              <div class="col-sm-10">
+              <div class="col-sm-6">
                 <input type="text" class="form-control" id="update_promotion_id" required
                   placeholder="Enter ID of Promotion to Update">
               </div>
-            </div>
-
-            <!-- creator UUID -->
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="update_promotion_creator">Creator's UUID:</label>
-              <div class="col-sm-10">
-                <input type="text" class="form-control" id="update_promotion_creator" placeholder="Update Creator UUID">
-              </div>
-            </div>
-
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="update_promotion_updater">Updated by UUID:</label>
-              <div class="col-sm-10">
-                <input type="text" class="form-control" id="update_promotion_updater" placeholder="Updated by UUID">
+              <div class="col-sm-4">
+                <button type="submit" class="btn btn-primary" id="retrieve-btn">Retrieve</button>
               </div>
             </div>
 
@@ -442,6 +389,15 @@
                   <option value="true">Active</option>
                   <option value="false">Inactive</option>
                 </select>
+              </div>
+            </div>
+
+            <!-- Additional Metadata (JSON) -->
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="update_promotion_extra">Additional Metadata:</label>
+              <div class="col-sm-10">
+                <input type="text" class="form-control" id="update_promotion_extra"
+                  placeholder="Enter Additional Metadata as JSON">
               </div>
             </div>
 

--- a/service/static/js/state_manager.js
+++ b/service/static/js/state_manager.js
@@ -1,7 +1,11 @@
 const StateManager = (() => {
-    /** @type {'start_date' | 'end_date'|'date_range'|null} */
+    /** 
+     * @type {{dateType: 'start_date' | 'end_date' | 'date_range' | null, creator: string | null, updater: string | null}}
+     */
     const state = {
-        dateType: null
+        dateType: null,
+        creator: null,
+        updater: null
     };
 
     return {
@@ -11,6 +15,20 @@ const StateManager = (() => {
         setDateType: (newType) => {
             state.dateType = newType;
             console.log('Date Type updated to:', state.dateType);
+        },
+        getCreator: () => {
+            return state.creator;
+        },
+        setCreator: (newCreator) => {
+            state.creator = newCreator;
+            console.log('Creator updated to:', state.creator);
+        },
+        getUpdater: () => {
+            return state.updater;
+        },
+        setUpdater: (newUpdater) => {
+            state.updater = newUpdater;
+            console.log('Updater updated to:', state.updater);
         }
     };
 })();

--- a/service/static/js/utils.js
+++ b/service/static/js/utils.js
@@ -56,14 +56,12 @@ const clearForm = (type) => {
         case 'search':
             $('#searchPromotionForm')[0].reset();
             break;
-        case 'retrieve':
-            $('#retrievePromotionForm')[0].reset();
-            break;
         case 'delete':
             $('#deletePromotionForm')[0].reset();
             break;
         case 'update':
             $('#updatePromotionForm')[0].reset();
+            $('#update_promotion_id').prop('disabled', false);
             break;
         default:
             console.error("Invalid form type specified");
@@ -106,4 +104,22 @@ const toggleActiveState = (type) => {
 
     // Ensure active fields are fully visible
     $(activeInputIDs.join(',')).removeClass('text-muted').css('opacity', 1);
+}
+
+const updateFormData = (promotion, type) => {
+    switch (type) {
+        case 'update-fill':
+            const formPrefix = 'update_promotion_';
+
+            $(`#${formPrefix}name`).val(promotion.name);
+            $(`#${formPrefix}description`).val(promotion.description);
+            $(`#${formPrefix}product_ids`).val(promotion.product_ids.join(', ')); // Assuming product_ids is always an array
+            $(`#${formPrefix}start_date`).val(promotion.start_date.slice(0, 10)); // Adjust to match input date format
+            $(`#${formPrefix}end_date`).val(promotion.end_date.slice(0, 10)); // Adjust to match input date format
+            $(`#${formPrefix}active_status`).val(promotion.active_status.toString());
+            $(`#${formPrefix}extra`).val(promotion.extra ? JSON.stringify(promotion.extra, null) : '');
+            break;
+        default:
+            break;
+    }
 }

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -21,6 +21,7 @@ TestPromotion API Service Test Suite
 # pylint: disable=duplicate-code
 import os
 import logging
+import json
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -32,6 +33,7 @@ from wsgi import app
 from service.common import status
 from service.models import db, Promotion
 from .factories import PromotionFactory
+
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -334,8 +336,13 @@ class TestPromotionResourceService(TestCase):
         """It should Delete a Promotion even if it doesn't exist"""
         non_existent_id = uuid4()  # Generate a random UUID
         response = self.client.delete(f"{BASE_URL}/{non_existent_id}")
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        response_data = json.loads(response.data)
+        expected_message = (
+            f"404 Not Found: Promotion with id '{non_existent_id}' was not found."
+        )
+        self.assertEqual(response_data["message"], expected_message)
 
     # ----------------------------------------------------------
     # TEST INVALID METHODS


### PR DESCRIPTION
### Changes
- Modified the delete API to return HTTP 204 if the promotion is found and deleted, and HTTP 404 if no corresponding promotion exists.
- Added a sad path scenario for the deletion of a promotion.
- Merged the retrieve and update promotion functionalities into a single tab for a streamlined user interface.
- set up logger in steps for debugging 